### PR TITLE
feat: add sponsored transaction support for gasless relay

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -155,6 +155,7 @@ export class X402PaymentClient {
         anchorMode: AnchorMode.Any,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction (signed but not broadcast)
@@ -220,6 +221,7 @@ export class X402PaymentClient {
         postConditionMode: PostConditionMode.Allow,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction (signed but not broadcast)
@@ -262,6 +264,7 @@ export class X402PaymentClient {
         anchorMode: AnchorMode.Any,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction
@@ -344,6 +347,7 @@ export class X402PaymentClient {
         postConditionMode: PostConditionMode.Allow,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction
@@ -426,6 +430,7 @@ export class X402PaymentClient {
         postConditionMode: PostConditionMode.Allow,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction (signed but not broadcast)
@@ -493,6 +498,7 @@ export class X402PaymentClient {
         postConditionMode: PostConditionMode.Allow,
         ...(details.nonce !== undefined && { nonce: details.nonce }),
         ...(details.fee !== undefined && { fee: details.fee }),
+        ...(details.sponsored && { sponsored: true, fee: 0n }),
       };
 
       // Create transaction

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   decodeXPaymentResponse,
   encodeXPaymentResponse,
 } from './interceptor';
+export type { SignPaymentOptions, PaymentInterceptorConfig } from './interceptor';
 
 // Legacy client (class-based)
 export { X402PaymentClient } from './client';

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,9 @@ export interface PaymentDetails {
   /** Optional fee (auto-estimated if not provided) */
   fee?: bigint;
 
+  /** Build as sponsored transaction (for gasless relay) */
+  sponsored?: boolean;
+
   /** Token type (defaults to STX) */
   tokenType?: TokenType;
 


### PR DESCRIPTION
## Summary

- Add `sponsored?: boolean` to `PaymentDetails` interface
- Thread sponsored flag through all transaction builders
- Add `PaymentInterceptorConfig` for axios interceptor
- When `sponsored=true`, transactions are built with `fee: 0n` for sponsor relay services

## Usage

```typescript
// Client-side: build sponsored transaction
const signedTx = await client.signSTXTransfer({
  ...details,
  sponsored: true
});

// Interceptor: configure for gasless
const api = withPaymentInterceptor(axios.create(), account, { sponsored: true });
```

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)